### PR TITLE
Add repodata mirror type

### DIFF
--- a/mirror2swift/mirror2swift.py
+++ b/mirror2swift/mirror2swift.py
@@ -11,6 +11,7 @@ import urlparse
 import yaml
 import gzip
 import StringIO
+import logging as log
 
 
 def get_weblisting_uri_list(base_url, suffix=""):
@@ -32,22 +33,23 @@ def get_repodata_uri_list(base_url):
     uri_list = ["repodata/repomd.xml"]
     repomd_url = "%s%s" % (base_url, uri_list[0])
 
-    # Get repomod.xml
+    log.debug("Discovering %s" % repomd_url)
     resp = requests.get(repomd_url)
     dom = lxml.html.fromstring(resp.content)
     filelist = None
     for uri in dom.xpath('//location/@href'):
         uri_list.append(uri)
 
-    # Get primary.xml.gz
     filelist = filter(lambda x: x.endswith("primary.xml.gz"), uri_list)
     if len(filelist) != 1:
         raise RuntimeError("Couldn't find filelist in %s (%s)" % (
                             repomd_url, uri_list))
+    log.debug("Getting package list: %s%s" % (base_url, filelist[0]))
     resp = requests.get("%s%s" % (base_url, filelist[0]))
     filelist = gzip.GzipFile(fileobj=StringIO.StringIO(resp.content)).read()
 
     # Extract packages list
+    log.debug("Adding all primary packages location")
     dom = lxml.html.fromstring(filelist)
     for uri in dom.xpath('//location/@href'):
         uri_list.append(uri)
@@ -58,6 +60,7 @@ def get_container_list(url, prefix=None):
     url += "?format=json"
     if prefix:
         url += "&prefix=%s" % prefix
+    log.debug("Listing swift container %s" % url)
     resp = requests.get(url)
     return [o.get('name') for o in resp.json()]
 
@@ -83,16 +86,19 @@ def upload_missing(download_url, swift_url, swift_key, update=False):
         swift_resp = requests.head(swift_url)
         if (mirror_resp.headers.get('Content-Length') ==
                 swift_resp.headers.get('Content-Length')):
+            log.debug("%s: already cached" % download_url)
             return True
     parsed = urlparse.urlparse(swift_url)
     resp = requests.get(download_url, stream=True)
     if resp.ok:
+        log.debug("%s: caching to %s" % (download_url, swift_url))
         sig, expires = get_tempurl(parsed.path, swift_key)
         tempurl = "%s?temp_url_sig=%s&temp_url_expires=%s" % (
             swift_url, sig, expires)
         r = requests.put(tempurl, data=resp.content)
         return r.ok
     else:
+        log.error("%s: get failed (%s)" % (download_url, str(resp)))
         return False
 
 
@@ -104,8 +110,15 @@ def get_config(filename):
             raise exc
 
 
+def setup_log(args):
+    lvl = log.DEBUG if args.debug else log.INFO
+    log.basicConfig(format='*** %(levelname)s:\t%(message)s\033[m', level=lvl)
+    log.getLogger("requests").setLevel(log.WARNING)
+
+
 def main():
     parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument("--debug", action="store_const", const=True)
     parser.add_argument('filename', help="YAML config file")
     parser.add_argument(
         '--noop', action='store_true', help="Noop - only compare mirrors")
@@ -114,6 +127,7 @@ def main():
         but differ in size. Objects are skipped by default if they exist")
 
     args = parser.parse_args()
+    setup_log(args)
     config = get_config(args.filename)
     for name, entry in config.items():
         uris = []
@@ -129,8 +143,10 @@ def main():
                 mirror_url = "%s/" % mirror_url
 
             if mirror_type == 'repodata':
+                log.info("Getting repodata_uri_list %s" % mirror_url)
                 uris += get_repodata_uri_list(mirror_url)
             else:
+                log.info("Getting weblisting_uri_list %s" % mirror_url)
                 uris += get_weblisting_uri_list(mirror_url)
 
             objs = []
@@ -142,9 +158,10 @@ def main():
             else:
                 missing = get_missing(uris, objs)
             if not missing:
+                log.info("%s: is up-to-date (%s)" % (name, swift_url))
                 continue
-            print "Uploading %d missing files for mirror %s\n" % (
-                len(missing), name)
+            log.info("Uploading %d missing files for mirror %s (%s)\n" % (
+                     len(missing), name, swift_url))
             for m in missing:
                 print m + "...",
                 if args.noop:

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -1,6 +1,7 @@
 first:
   mirrors:
   - name: base
+    type: repodata
     url: 'http://mirror.eu.oneandone.net/linux/distributions/centos/7/os/x86_64/'
     prefix: 'base/'
   swift:

--- a/tests/test_mirror2swift.py
+++ b/tests/test_mirror2swift.py
@@ -18,7 +18,7 @@ class TestMirror2Swift(unittest.TestCase):
             MagicMock(content=html),
             MagicMock(content='<a href="sample%2B.rpm">sample+.rpm</a>')]
         mock_get.side_effect = content
-        uris = mirror2swift.get_uri_list('http://some/url/')
+        uris = mirror2swift.get_weblisting_uri_list('http://some/url/')
         mock_get.assert_has_calls(
             [call('http://some/url/'), call('http://some/url/pkgs/')])
         self.assertEqual(['pkgs/sample+.rpm'], uris)


### PR DESCRIPTION
This change adds a 'type' parameter for mirror to support
transparent repodata based crawling. When set to 'repodata'
the tool fetchs repomd.xml and primary.xml.gz file to list
all the required files for a functional rpm mirror.

To make it explicit, the legacy get_uri_list is renamed to
get_weblisting_uri_list.
