### PR TITLE
Always try to gunzip repodata

### DIFF
--- a/mirror2swift/mirror2swift.py
+++ b/mirror2swift/mirror2swift.py
@@ -55,10 +55,9 @@ def get_repodata_uri_list(base_url):
     log.debug("Getting package list: %s%s" % (base_url, filelist[0]))
     resp = requests.get("%s%s" % (base_url, filelist[0]))
 
-    content_type = resp.headers.get('Content-Type', '')
-    if 'gzip' in content_type:
+    try:
         filelist = gzip.GzipFile(fileobj=StringIO.StringIO(resp.content)).read()
-    else:
+    except:
         filelist = resp.content
 
     # Extract packages list


### PR DESCRIPTION
This change better support some mirrors that doesn't set the proper
Content-Type and return gziped data as application/xml.